### PR TITLE
Fix workflow for deploy-pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
         with:
-          publish_dir: ./ 
+          path: ./
+      - id: deployment
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
## Summary
- fix the GitHub Pages workflow by uploading an artifact before deployment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68736fd47990832f9e3a833c94b8e921