### PR TITLE
Adjust pages workflow for manual enablement

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Build site
         run: npm run build --if-present
 
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
-        with:
-          enablement: auto
-
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 このリポジトリは CCU（ココフォリア・ログアップローダー）が
 GitHub Pages リポジトリを作成するときのテンプレートです。
-初回のみPageを公開する必要があります。
+初回のみ GitHub Pages の公開設定を手動で行ってください。
+公開後はワークフローが自動で更新を反映します。
 
 - 初期ページ: `index.html`  
 - 検索エンジン避け: `<meta name="robots" content="noindex,nofollow">` と `norobot.js`  


### PR DESCRIPTION
## Summary
- disable automatic GitHub Pages enablement by removing the configure step
- explain in the README that pages should be enabled manually while updates remain automatic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68739ac8a0d8832f8a65d6ca8343f8a3