### PR TITLE
Fix mobile drag on delete buttons

### DIFF
--- a/loglist.js
+++ b/loglist.js
@@ -14,6 +14,8 @@ document.addEventListener("DOMContentLoaded", () => {
   // Sortable 設定
   new Sortable(list, {
     animation: 150,
+    filter: '.btn-delete',
+    preventOnFilter: false,
     onEnd: () => {
       pendingOrder = Array.from(list.children).map(li => li.dataset.path);
       confirmBtn.disabled = false;


### PR DESCRIPTION
## Summary
- update Sortable.js options to filter out delete button taps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877be419078832fa108ad305ba23efb