### PR TITLE
Fix delete button click on touch devices

### DIFF
--- a/loglist.js
+++ b/loglist.js
@@ -15,10 +15,18 @@ document.addEventListener("DOMContentLoaded", () => {
   new Sortable(list, {
     animation: 150,
     filter: '.btn-delete',
-    preventOnFilter: false,
+    // Prevent drag when starting from the delete button
+    preventOnFilter: true,
     onEnd: () => {
       pendingOrder = Array.from(list.children).map(li => li.dataset.path);
       confirmBtn.disabled = false;
+    }
+  });
+
+  // Stop pointer events on the delete button from initiating drag
+  list.addEventListener('pointerdown', e => {
+    if (e.target.closest('.btn-delete')) {
+      e.stopPropagation();
     }
   });
 


### PR DESCRIPTION
## Summary
- prevent Sortable from initiating drag when tapping a delete button
- block pointer events on delete buttons from starting a drag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877c2aa3cc4832f9b51a20be3597933