### PR TITLE
Add drag delay on touch for Sortable

### DIFF
--- a/loglist.js
+++ b/loglist.js
@@ -14,6 +14,8 @@ document.addEventListener("DOMContentLoaded", () => {
   // Sortable 設定
   new Sortable(list, {
     animation: 150,
+    delay: 200,
+    delayOnTouchOnly: true,
     // Disable dragging when touching delete buttons or links
     filter: '.btn-delete, a',
 


### PR DESCRIPTION
## Summary
- configure Sortable with a small touch delay so links are clickable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877cd736078832f81c2732e0c0ed6d8